### PR TITLE
Fix dFoldr if the lambda has a nontrivial closure

### DIFF
--- a/src/Test.hs
+++ b/src/Test.hs
@@ -371,6 +371,22 @@ fastTests =
            arbitrarySizedFractional
            E.foldProd)
     , testProperty "foldProd2" (propAll E.foldProd2)
+    -- foldrSum: For small inputs, finite differencing is still accurate enough
+    , testProperty
+        "foldrSum-small"
+        (propAll'
+           (genVect :: Gen (Vect 4))
+           (resize 1 . genWithPrimal)
+           (const arbitrarySizedFractional)
+           (const id)
+           E.foldrSum)
+    -- foldrSum: For larger inputs, we only compare forward AD versus reverse AD
+    , testProperty
+        "foldrSum-noFD"
+        (propFwdVsRev'
+           (genVect :: Gen (Vect 8))
+           arbitrarySizedFractional
+           E.foldrSum)
     ]
 
 slowTests :: TestTree

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -198,7 +198,7 @@ dFoldr f i v =
     let s = V.prescanr (curry (fst . f)) i v
         vvps = V.zip v (V.zip v' s)
         g (vi, (vpi, si)) acc =
-          lApp (snd (f (vi, si))) (vpi, f' (vi, si) `plus` acc)
+          f' (vi, si) `plus` lApp (snd (f (vi, si))) (vpi, acc)
      in V.foldr g i' vvps
 
 dtFoldr ::


### PR DESCRIPTION
The added test exposes a bug in the implementation of `dFoldr`, which surfaces if the `Foldr` function argument closes over a variable with nonzero tangent. Adding the adjoints of the loop accumulator the other way round makes the test succeed.

However, I have no idea why this order is correct (is it?) and the previous version isn't. Hence I feel uncomfortable with this, because both implementations are type-correct and use all the available information -- which is mostly all the heuristic that I personally have for this stuff. Do you have any insight in this, @VMatthijs?